### PR TITLE
added Pocket integration

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/s3ththompson/berliner",
-	"GoVersion": "go1.4",
+	"GoVersion": "go1.4.2",
 	"Packages": [
 		"./..."
 	],
@@ -38,6 +38,14 @@
 		{
 			"ImportPath": "github.com/bjarneh/latinx",
 			"Rev": "4dfe9ba2a293f28a5e06fc7ffe56b1d71a47b8c8"
+		},
+		{
+			"ImportPath": "github.com/geoffreylitt/go-pocket/api",
+			"Rev": "5be05f0a26c6217f8b64ad1c7c8aec449959b468"
+		},
+		{
+			"ImportPath": "github.com/geoffreylitt/go-pocket/auth",
+			"Rev": "5be05f0a26c6217f8b64ad1c7c8aec449959b468"
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/mousetrap",

--- a/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api/add.go
+++ b/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api/add.go
@@ -1,0 +1,34 @@
+package api
+
+// AddOption is the options for retrieve API.
+type AddOption struct {
+	Url					string				 `json:"url,omitempty"`
+	Title				string				 `json:"title,omitempty"`
+	Tags				string				 `json:"tags,omitempty"`
+}
+
+type addAPIOptionWithAuth struct {
+	*AddOption
+	authInfo
+}
+
+type AddResult struct {
+	Status   int
+	Complete int
+}
+
+// Retrieve returns the in Pocket
+func (c *Client) Add(options *AddOption) (*AddResult, error) {
+	data := addAPIOptionWithAuth{
+		authInfo:       c.authInfo,
+		AddOption: 			options,
+	}
+
+	res := &AddResult{}
+	err := PostJSON("/v3/add", data, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api/api.go
+++ b/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api/api.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// The API origin
+var Origin = "https://getpocket.com"
+
+// Client represents a Pocket client that grants OAuth access to your application
+type Client struct {
+	authInfo
+}
+
+type authInfo struct {
+	ConsumerKey string `json:"consumer_key"`
+	AccessToken string `json:"access_token"`
+}
+
+// NewClient creates a new Pocket client.
+func NewClient(consumerKey, accessToken string) *Client {
+	return &Client{
+		authInfo: authInfo{
+			ConsumerKey: consumerKey,
+			AccessToken: accessToken,
+		},
+	}
+}
+
+func doJSON(req *http.Request, res interface{}) error {
+	req.Header.Add("X-Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("got response %d; X-Error=[%s]", resp.StatusCode, resp.Header.Get("X-Error"))
+	}
+
+	return json.NewDecoder(resp.Body).Decode(res)
+}
+
+// PostJSON posts the data to the API endpoint, storing the result in res.
+func PostJSON(action string, data, res interface{}) error {
+	body, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", Origin+action, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	return doJSON(req, res)
+}

--- a/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api/modify.go
+++ b/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api/modify.go
@@ -1,0 +1,42 @@
+package api
+
+// Action represents one action in a bulk modify requests.
+type Action struct {
+	Action string `json:"action"`
+	ItemID int    `json:"item_id,string"`
+}
+
+// NewArchiveAction creates an acrhive action.
+func NewArchiveAction(itemID int) *Action {
+	return &Action{
+		Action: "archive",
+		ItemID: itemID,
+	}
+}
+
+// ModifyResult represents the modify API's result.
+type ModifyResult struct {
+	// The results for each of the requested actions.
+	ActionResults []bool
+	Status        int
+}
+
+type modifyAPIOptionsWithAuth struct {
+	Actions []*Action `json:"actions"`
+	authInfo
+}
+
+// Modify requests bulk modification on items.
+func (c *Client) Modify(actions ...*Action) (*ModifyResult, error) {
+	res := &ModifyResult{}
+	data := modifyAPIOptionsWithAuth{
+		authInfo: c.authInfo,
+		Actions:  actions,
+	}
+	err := PostJSON("/v3/send", data, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api/retrieve.go
+++ b/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api/retrieve.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"bytes"
+	"strconv"
+	"time"
+)
+
+// RetrieveOption is the options for retrieve API.
+type RetrieveOption struct {
+	State       State          `json:"state,omitempty"`
+	Favorite    FavoriteFilter `json:"favorite,omitempty"`
+	Tag         string         `json:"tag,omitempty"`
+	ContentType ContentType    `json:"contentType,omitempty"`
+	Sort        Sort           `json:"sort,omitempty"`
+	DetailType  DetailType     `json:"detailType,omitempty"`
+	Search      string         `json:"search,omitempty"`
+	Domain      string         `json:"domain,omitempty"`
+	Since       int            `json:"since,omitempty"`
+	Count       int            `json:"count,omitempty"`
+	Offset      int            `json:"offset,omitempty"`
+}
+
+type State string
+
+const (
+	StateUnread  State = "unread"
+	StateArchive       = "archive"
+	StateAll           = "all"
+)
+
+type ContentType string
+
+const (
+	ContentTypeArticle ContentType = "article"
+	ContentTypeVideo               = "video"
+	ContentTypeImage               = "image"
+)
+
+type Sort string
+
+const (
+	SortNewest Sort = "newest"
+	SortOldest      = "oldest"
+	SortTitle       = "title"
+	SortSite        = "site"
+)
+
+type DetailType string
+
+const (
+	DetailTypeSimple   DetailType = "simple"
+	DetailTypeComplete            = "complete"
+)
+
+type FavoriteFilter string
+
+const (
+	FavoriteFilterUnspecified FavoriteFilter = ""
+	FavoriteFilterUnfavorited                = "0"
+	FavoriteFilterFavorited                  = "1"
+)
+
+type retrieveAPIOptionWithAuth struct {
+	*RetrieveOption
+	authInfo
+}
+
+type RetrieveResult struct {
+	List     map[string]Item
+	Status   int
+	Complete int
+	Since    int
+}
+
+type ItemStatus int
+
+const (
+	ItemStatusUnread   ItemStatus = 0
+	ItemStatusArchived            = 1
+	ItemStatusDeleted             = 2
+)
+
+type ItemMediaAttachment int
+
+const (
+	ItemMediaAttachmentNoMedia  ItemMediaAttachment = 0
+	ItemMediaAttachmentHasMedia                     = 1
+	ItemMediaAttachmentIsMedia                      = 2
+)
+
+type Item struct {
+	ItemID        int        `json:"item_id,string"`
+	ResolvedId    int        `json:"resolved_id,string"`
+	GivenURL      string     `json:"given_url"`
+	ResolvedURL   string     `json:"resolved_url"`
+	GivenTitle    string     `json:"given_title"`
+	ResolvedTitle string     `json:"resolved_title"`
+	Favorite      int        `json:",string"`
+	Status        ItemStatus `json:",string"`
+	Excerpt       string
+	IsArticle     int                 `json:"is_article,string"`
+	HasImage      ItemMediaAttachment `json:"has_image,string"`
+	HasVideo      ItemMediaAttachment `json:"has_video,string"`
+	WordCount     int                 `json:"word_count,string"`
+
+	// Fields for detailed response
+	Tags    map[string]map[string]interface{}
+	Authors map[string]map[string]interface{}
+	Images  map[string]map[string]interface{}
+	Videos  map[string]map[string]interface{}
+
+	// Fields that are not documented but exist
+	SortId        int  `json:"sort_id"`
+	TimeAdded     Time `json:"time_added"`
+	TimeUpdated   Time `json:"time_updated"`
+	TimeRead      Time `json:"time_read"`
+	TimeFavorited Time `json:"time_favorited"`
+}
+
+type Time time.Time
+
+func (t *Time) UnmarshalJSON(b []byte) error {
+	i, err := strconv.ParseInt(string(bytes.Trim(b, `"`)), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*t = Time(time.Unix(i, 0))
+
+	return nil
+}
+
+// URL is an alias for ResolvedURL
+func (item Item) URL() string {
+	return item.ResolvedURL
+}
+
+// Title is an alias for ResolvedTitle
+func (item Item) Title() string {
+	return item.ResolvedTitle
+}
+
+// Retrieve returns the in Pocket
+func (c *Client) Retrieve(options *RetrieveOption) (*RetrieveResult, error) {
+	data := retrieveAPIOptionWithAuth{
+		authInfo:       c.authInfo,
+		RetrieveOption: options,
+	}
+
+	res := &RetrieveResult{}
+	err := PostJSON("/v3/get", data, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/auth/auth.go
+++ b/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/auth/auth.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/s3ththompson/berliner/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api"
+)
+
+type RequestToken struct {
+	Code string `json:"code"`
+}
+
+type Authorization struct {
+	AccessToken string `json:"access_token"`
+	Username    string `json:"username"`
+}
+
+func ObtainRequestToken(consumerKey, redirectURL string) (*RequestToken, error) {
+	res := &RequestToken{}
+	err := api.PostJSON(
+		"/v3/oauth/request",
+		map[string]string{
+			"consumer_key": consumerKey,
+			"redirect_uri": redirectURL,
+		},
+		res,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func ObtainAccessToken(consumerKey string, requestToken *RequestToken) (*Authorization, error) {
+	res := &Authorization{}
+	err := api.PostJSON(
+		"/v3/oauth/authorize",
+		map[string]string{
+			"consumer_key": consumerKey,
+			"code":         requestToken.Code,
+		},
+		res,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func GenerateAuthorizationURL(requestToken *RequestToken, redirectURL string) string {
+	values := url.Values{"request_token": {requestToken.Code}, "redirect_uri": {redirectURL}}
+	return fmt.Sprintf("%s/auth/authorize?%s", api.Origin, values.Encode())
+}

--- a/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/auth/auth_test.go
+++ b/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/auth/auth_test.go
@@ -1,0 +1,30 @@
+package auth_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/s3ththompson/berliner/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api"
+	"github.com/s3ththompson/berliner/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/auth"
+)
+
+func TestObtainRequestToken(t *testing.T) {
+	RegisterTestingT(t)
+
+	theCode := "4a334434-a4ac-38fa-a747-4049b4"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(fmt.Sprintf(`{"code":"%s"}`, theCode)))
+	}))
+	defer ts.Close()
+
+	api.Origin = ts.URL
+
+	res, err := auth.ObtainRequestToken("", "http://www.example.com/")
+
+	Expect(err).To(BeNil())
+	Expect(res.Code).To(Equal(theCode))
+}

--- a/berliner.go
+++ b/berliner.go
@@ -33,7 +33,14 @@ func main() {
 		Run:   Render,
 	}
 
-	Berliner.AddCommand(cmdFetch, cmdParse, cmdRender)
+	cmdPocket := &cobra.Command{
+		Use:   "_pocket",
+		Short: "Send to Pocket",
+		Long:  "Send articles to your Pocket",
+		Run:   Pocket,
+	}
+
+	Berliner.AddCommand(cmdFetch, cmdParse, cmdRender, cmdPocket)
 
 	Berliner.Execute()
 }

--- a/pocket.go
+++ b/pocket.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/s3ththompson/berliner/Godeps/_workspace/src/github.com/spf13/cobra"
+
+	"github.com/s3ththompson/berliner/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/api"
+	"github.com/s3ththompson/berliner/Godeps/_workspace/src/github.com/geoffreylitt/go-pocket/auth"
+
+	"github.com/s3ththompson/berliner/extractors"
+)
+
+func Pocket(cmd *cobra.Command, args []string) {
+	//todo: put this somewhere else?
+	const consumerKey = "41271-5803fea25a99fa750709a512"
+
+	// todo: restore access token from saved config file, rather
+	//       than requiring authorization every time
+	accessToken, err := obtainAccessToken(consumerKey)
+	if err != nil {
+		panic(err)
+	}
+
+	client := api.NewClient(consumerKey, accessToken.AccessToken)
+
+	posts, err := extractors.ReadPosts(os.Stdin)
+
+	fmt.Println("Adding these articles to Pocket...")
+	for _, post := range posts {
+		// append berliner tag for easy Pocket searching later
+		tags := append(post.Tags, "berliner")
+		tagsStr := strings.Join(tags, ",")
+
+		options := &api.AddOption{
+			Url:   post.Permalink,
+			Title: post.Title,
+			Tags:  tagsStr,
+		}
+
+		_, err := client.Add(options)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println(post.Title)
+	}
+}
+
+func obtainAccessToken(consumerKey string) (*auth.Authorization, error) {
+	ch := make(chan struct{})
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if req.URL.Path == "/favicon.ico" {
+				http.Error(w, "Not Found", 404)
+				return
+			}
+
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintln(w, "Authorized. Please return to your shell.")
+			ch <- struct{}{}
+		}))
+	defer ts.Close()
+
+	redirectURL := ts.URL
+
+	requestToken, err := auth.ObtainRequestToken(consumerKey, redirectURL)
+	if err != nil {
+		return nil, err
+	}
+
+	url := auth.GenerateAuthorizationURL(requestToken, redirectURL)
+
+	fmt.Println("If your web browser doesn't automatically open, copy paste this URL to authorize Pocket access.")
+	fmt.Println(url)
+
+	// Use open command to automatically open authorization page
+	openCmd := exec.Command("open", url)
+	openCmd.Start()
+
+	<-ch
+
+	return auth.ObtainAccessToken(consumerKey, requestToken)
+}


### PR DESCRIPTION
This branch adds the ability to integrate with Pocket and add a set of fetched URLs to your Pocket feed with a "berliner" tag.

Example usage:
`echo "news.com/rss.xml" | berliner _fetch | berliner _pocket`

It requires user authorization with a web browser every time it's run, which can be improved in the future by storing an access token in a configuration file.